### PR TITLE
Model measles nga01

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ _param_*.json
 *.png
 *.svg
 
+venv/
+env/
 __pycache__/
 *output/
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,17 @@ _param_*.json
 *.png
 *.svg
 
-venv/
-env/
 __pycache__/
 *output/
 
 # Sphinx documentation
 docs/_build/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/model_measles_nga01/Assets/python/dtk_post_process.py
+++ b/model_measles_nga01/Assets/python/dtk_post_process.py
@@ -79,7 +79,7 @@ def application(output_path):
 
   for adm1_name in adm1_dict:
     rep_bool          = np.isin(gdata.data_vec_node,adm1_dict[adm1_name])
-    (inf_mo, tstamps) = np.histogram(gdata.data_vec_time,
+    (inf_mo, tstamps) = np.histogram(gdata.data_vec_time[rep_bool],
                                      bins    = BIN_EDGES,
                                      weights = gdata.data_vec_mcw[rep_bool])
 


### PR DESCRIPTION
I was getting an error for simulations that entered the SQL logging period (3 years):

```
Traceback (most recent call last):
  File "/mnt/idm2/home3/krosenfeld/MEAS-NGA-Base02_20240120_204014/a89/2d8/1fd/a892d81f-d4b7-ee11-aa0f-9440c9be2c51/./Assets/python/dtk_post_process.py", line 81, in application
    (inf_mo, tstamps) = np.histogram(gdata.data_vec_time,
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/py_env/lib/python3.11/site-packages/numpy/lib/histograms.py", line 778, in histogram
    a, weights = _ravel_and_check_weights(a, weights)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/py_env/lib/python3.11/site-packages/numpy/lib/histograms.py", line 297, in _ravel_and_check_weights
    raise ValueError(
ValueError: weights should have the same shape as a.
00:03:37 [0] [E] [Eradication] 
```

This pull request should fix that!

It also adds virtual environment folders to the .gitignore.