### PR TITLE
EXE and ENV are resolved by emod_reduce in emod_exp

### DIFF
--- a/local_python/emod_calib.py
+++ b/local_python/emod_calib.py
@@ -19,8 +19,7 @@ EX_VAL = -1.0e10
 # Paths
 PATH_PYTHON   = os.path.abspath(os.path.join('Assets','python'))
 PATH_DATA     = os.path.abspath(os.path.join('Assets','data'))
-PATH_ENV      = os.path.abspath(os.path.join('Assets','EMOD_ENV.id'))
-PATH_EXE      = os.path.abspath(os.path.join('Assets','EMOD_EXE.id'))
+PATH_EXE      = os.path.abspath(os.path.join('Assets'))
 
 
 def calibration_daemon():
@@ -86,7 +85,7 @@ def calibration_daemon():
       json.dump(param_dict_new, fid01)
 
     # Create experiment object
-    exp_obj_new = exp_from_def_file(PATH_EXP_DEF, PATH_PYTHON, PATH_ENV, PATH_EXE, PATH_DATA)
+    exp_obj_new = exp_from_def_file(PATH_EXP_DEF, PATH_PYTHON, PATH_EXE, PATH_DATA)
 
     # Send experiment to COMPS; start processing; wait until done
     plat_obj.run_items(exp_obj_new)


### PR DESCRIPTION
When running the calibrationi examples in `model_demographics01` and `model_measles_cod01`, I was running into an error:
```
Traceback (most recent call last):
  File "/mnt/idm2/home/krosenfeld/workitems/a0b/a1d/b90/a0ba1db9-02d4-ee11-aa11-b88303911bc1/Assets/emod_calib.py", line 110, in <module>
    calibration_daemon()
  File "/mnt/idm2/home/krosenfeld/workitems/a0b/a1d/b90/a0ba1db9-02d4-ee11-aa11-b88303911bc1/Assets/emod_calib.py", line 89, in calibration_daemon
    exp_obj_new = exp_from_def_file(PATH_EXP_DEF, PATH_PYTHON, PATH_ENV, PATH_EXE, PATH_DATA)
TypeError: exp_from_def_file() takes 4 positional arguments but 5 were given
```

This pull request seems to fix the issue.