### PR TITLE
Added analytics to mkdocs.yml to enable feedback

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,8 @@ extra:
     - icon: fontawesome/brands/slack
       link: https://gatesfoundation.enterprise.slack.com/
   analytics:
+    provider: google
+    property: # no tracking until we can implement OneTrust cookie consent
     feedback:
       title: Was this page helpful?
       ratings:


### PR DESCRIPTION
Although we currently aren't tracking metrics due to issues getting OneTrust implemented, we need to have the provider and property keys listed in the YAML file to enable the feedback survey.